### PR TITLE
 ci: harden Flutter CI/CD (triggers on main/develop, concurrency, pin…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,31 +2,72 @@ name: Flutter CI/CD
 
 on:
   push:
-    branches: [ "develop" ] 
+    branches: [ main, develop ]
   pull_request:
-    branches: [ "develop" ] 
+    branches: [ main, develop ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build_and_test:
     name: Build, Analyze & Test
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          flutter-version: '3.19.6'
 
-      - name: Install dependencies
+      - name: Cache pub packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Flutter pub get
         run: flutter pub get
-      
-      - name: Generate localizations
-        run: flutter gen-l10n
-        
+
+      - name: Generate localizations (if configured)
+        run: |
+          if [ -f l10n.yaml ]; then
+            flutter gen-l10n
+          fi
+
+      - name: Enforce formatting
+        run: flutter format --set-exit-if-changed .
+
       - name: Analyze code
         run: flutter analyze
 
-      - name: Run tests
-        run: flutter test
+      - name: Run tests with coverage
+        env:
+          CI: true
+        run: flutter test --coverage --no-pub
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: coverage/lcov.info


### PR DESCRIPTION
## 📋 Description
Hardens the Flutter CI/CD pipeline:
- Triggers on push and PR to main and develop
- Concurrency with cancel-in-progress
- Java 17 (Temurin) and Flutter 3.19.6 (stable) pinned
- Pub cache enabled
- gen-l10n runs only if l10n.yaml exists
- Formatting enforced (flutter format --set-exit-if-changed)
- Static analysis (flutter analyze)
- Tests with coverage + lcov artifact upload

Workflow file: `.github/workflows/main.yml`

## 🔗 Related Issue
Fixes #19

## 🧪 Type of Change
- [x] 🔧 Configuration change

## 📝 How Has This Been Tested?
- [x] CI/CD pipeline passes
- [x] flutter analyze locally

## 📷 Screenshots (if applicable)
N/A

## ✅ Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests (N/A for CI config)
- [x] New and existing unit tests run in CI

## 🔄 Dependencies
- actions/checkout@v4
- actions/setup-java@v4
- subosito/flutter-action@v2
- actions/cache@v4
- actions/upload-artifact@v4

## 📚 Additional Notes
- Coverage artifact available at `coverage/lcov.info` in workflow artifacts.

**Issue Reference**: Closes #19
