### PR TITLE
Feat/visual brand identity

### DIFF
--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 class AppTheme {
   AppTheme._();
 
-  // Cores primárias (HSL: 214 100% 58%)
+  // ### Brand primary (fonte da verdade) ###
   static const Color primary = Color(0xFF3B82F6);
   static const Color primaryForeground = Color(0xFFFFFFFF);
 

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'brand_theme_colors.dart';
 
 class AppTheme {
   AppTheme._();
@@ -8,7 +11,7 @@ class AppTheme {
   static const Color primaryForeground = Color(0xFFFFFFFF);
 
   // Cores de fundo (HSL: 0 0% 98%)
-  static const Color background = Color(0xFFFAFAFA);
+  static const Color background = Color(0xFFF1F5F9);
   static const Color foreground = Color(0xFF334155); // HSL: 220 15% 20%
 
   // Cores secundárias (HSL: 214 20% 95%)
@@ -35,7 +38,129 @@ class AppTheme {
   static const Color card = Color(0xFFFFFFFF);
   static const Color cardForeground = Color(0xFF334155);
 
+  static final BrandThemeColors _brandLightColors = BrandThemeColors(
+    primaryTintedBackground: Color.alphaBlend(
+      primary.withValues(alpha: 0.08),
+      card,
+    ),
+    primaryBorder: primary.withValues(alpha: 0.2),
+    primaryHeadline: Color.alphaBlend(
+      Colors.black.withValues(alpha: 0.2),
+      primary,
+    ),
+    primaryBody: Color.alphaBlend(
+      Colors.white.withValues(alpha: 0.1),
+      primary,
+    ),
+    adviceCritical: const AdviceColors(
+      background: Color(0xFFFEF2F2),
+      icon: Color(0xFFEF4444),
+      title: Color(0xFFB91C1C),
+      text: Color(0xFF991B1B),
+    ),
+    adviceWarning: const AdviceColors(
+      background: Color(0xFFFFFBEB),
+      icon: Color(0xFFF59E0B),
+      title: Color(0xFFB45309),
+      text: Color(0xFF92400E),
+    ),
+    adviceGood: const AdviceColors(
+      background: Color(0xFFF0FDF4),
+      icon: Color(0xFF22C55E),
+      title: Color(0xFF15803D),
+      text: Color(0xFF166534),
+    ),
+    adviceInfo: const AdviceColors(
+      background: Color(0xFFEFF6FF),
+      icon: primary,
+      title: Color(0xFF1E40AF),
+      text: Color(0xFF1D4ED8),
+    ),
+    testRunning: const TestItemColors(
+      background: Color(0xFFEFF6FF),
+      border: Color(0xFF4D89FF),
+      iconContainer: Color(0xFFDBEAFE),
+      icon: Color(0xFF4D89FF),
+      text: Color(0xFF2563EB),
+      result: Color(0xFF2563EB),
+    ),
+    testComplete: const TestItemColors(
+      background: Color(0xFFF0FDF4),
+      border: Color(0xFF10B981),
+      iconContainer: Color(0xFFD1FAE5),
+      icon: Color(0xFF10B981),
+      text: Color(0xFF059669),
+      result: Color(0xFF047857),
+    ),
+    testError: const TestItemColors(
+      background: Color(0xFFFEF2F2),
+      border: Color(0xFFEF4444),
+      iconContainer: Color(0xFFFEE2E2),
+      icon: Color(0xFFEF4444),
+      text: Color(0xFFDC2626),
+      result: Color(0xFFB91C1C),
+    ),
+    testPending: const TestItemColors(
+      background: card,
+      border: Color(0xFFE5E7EB),
+      iconContainer: Color(0xFFF1F5F9),
+      icon: Color(0xFF94A3B8),
+      text: Color(0xFF64748B),
+      result: Color(0xFF94A3B8),
+    ),
+    signalExcellent: const Color(0xFF16A34A),
+    signalNormal: const Color(0xFFD97706),
+    signalPoor: const Color(0xFFDC2626),
+  );
+
   static ThemeData get lightTheme {
+    const baseTextTheme = TextTheme(
+      displayLarge: TextStyle(
+        fontSize: 32,
+        fontWeight: FontWeight.bold,
+        color: foreground,
+      ),
+      displayMedium: TextStyle(
+        fontSize: 28,
+        fontWeight: FontWeight.bold,
+        color: foreground,
+      ),
+      displaySmall: TextStyle(
+        fontSize: 24,
+        fontWeight: FontWeight.bold,
+        color: foreground,
+      ),
+      headlineMedium: TextStyle(
+        fontSize: 20,
+        fontWeight: FontWeight.w600,
+        color: foreground,
+      ),
+      titleLarge: TextStyle(
+        fontSize: 18,
+        fontWeight: FontWeight.w600,
+        color: foreground,
+      ),
+      titleMedium: TextStyle(
+        fontSize: 16,
+        fontWeight: FontWeight.w500,
+        color: foreground,
+      ),
+      bodyLarge: TextStyle(
+        fontSize: 16,
+        color: foreground,
+      ),
+      bodyMedium: TextStyle(
+        fontSize: 14,
+        color: foreground,
+      ),
+      bodySmall: TextStyle(
+        fontSize: 12,
+        color: mutedForeground,
+      ),
+    );
+
+    final textTheme = GoogleFonts.interTextTheme(baseTextTheme);
+
     return ThemeData(
       useMaterial3: true,
       brightness: Brightness.light,
@@ -48,7 +173,7 @@ class AppTheme {
         onSecondary: secondaryForeground,
         error: destructive,
         onError: destructiveForeground,
-        surface: background,
+        surface: card,
         onSurface: foreground,
       ),
 
@@ -140,50 +265,11 @@ class AppTheme {
       ),
 
       // Typography
-      textTheme: const TextTheme(
-        displayLarge: TextStyle(
-          fontSize: 32,
-          fontWeight: FontWeight.bold,
-          color: foreground,
-        ),
-        displayMedium: TextStyle(
-          fontSize: 28,
-          fontWeight: FontWeight.bold,
-          color: foreground,
-        ),
-        displaySmall: TextStyle(
-          fontSize: 24,
-          fontWeight: FontWeight.bold,
-          color: foreground,
-        ),
-        headlineMedium: TextStyle(
-          fontSize: 20,
-          fontWeight: FontWeight.w600,
-          color: foreground,
-        ),
-        titleLarge: TextStyle(
-          fontSize: 18,
-          fontWeight: FontWeight.w600,
-          color: foreground,
-        ),
-        titleMedium: TextStyle(
-          fontSize: 16,
-          fontWeight: FontWeight.w500,
-          color: foreground,
-        ),
-        bodyLarge: TextStyle(
-          fontSize: 16,
-          color: foreground,
-        ),
-        bodyMedium: TextStyle(
-          fontSize: 14,
-          color: foreground,
-        ),
-        bodySmall: TextStyle(
-          fontSize: 12,
-          color: mutedForeground,
-        ),
-      ),
+      extensions: <ThemeExtension<dynamic>>[
+        _brandLightColors,
+      ],
+
+      textTheme: textTheme,
     );
   }
 

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -181,27 +181,24 @@ class AppTheme {
       scaffoldBackgroundColor: background,
 
       // AppBar
-      appBarTheme: const AppBarTheme(
+      appBarTheme: AppBarTheme(
         backgroundColor: card,
         foregroundColor: foreground,
         elevation: 1,
-        shadowColor: Colors.black12,
+        shadowColor: const Color(0x0D1E293B),
         centerTitle: true,
-        titleTextStyle: TextStyle(
-          color: foreground,
-          fontSize: 20,
-          fontWeight: FontWeight.bold,
-        ),
-        iconTheme: IconThemeData(color: foreground),
+        titleTextStyle: textTheme.headlineMedium,
+        iconTheme: const IconThemeData(color: foreground),
       ),
 
       // Card
       cardTheme: CardThemeData(
         color: card,
-        elevation: 0,
+        elevation: 4,
+        shadowColor: const Color(0x141E293B),
+        surfaceTintColor: Colors.transparent,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(16),
-          side: const BorderSide(color: border, width: 1),
         ),
       ),
 

--- a/lib/core/theme/brand_theme_colors.dart
+++ b/lib/core/theme/brand_theme_colors.dart
@@ -7,12 +7,34 @@ class BrandThemeColors extends ThemeExtension<BrandThemeColors> {
     required this.primaryBorder,
     required this.primaryHeadline,
     required this.primaryBody,
+    required this.adviceCritical,
+    required this.adviceWarning,
+    required this.adviceGood,
+    required this.adviceInfo,
+    required this.testRunning,
+    required this.testComplete,
+    required this.testError,
+    required this.testPending,
+    required this.signalExcellent,
+    required this.signalNormal,
+    required this.signalPoor,
   });
 
   final Color primaryTintedBackground;
   final Color primaryBorder;
   final Color primaryHeadline;
   final Color primaryBody;
+  final AdviceColors adviceCritical;
+  final AdviceColors adviceWarning;
+  final AdviceColors adviceGood;
+  final AdviceColors adviceInfo;
+  final TestItemColors testRunning;
+  final TestItemColors testComplete;
+  final TestItemColors testError;
+  final TestItemColors testPending;
+  final Color signalExcellent;
+  final Color signalNormal;
+  final Color signalPoor;
 
   @override
   BrandThemeColors copyWith({
@@ -20,6 +42,17 @@ class BrandThemeColors extends ThemeExtension<BrandThemeColors> {
     Color? primaryBorder,
     Color? primaryHeadline,
     Color? primaryBody,
+    AdviceColors? adviceCritical,
+    AdviceColors? adviceWarning,
+    AdviceColors? adviceGood,
+    AdviceColors? adviceInfo,
+    TestItemColors? testRunning,
+    TestItemColors? testComplete,
+    TestItemColors? testError,
+    TestItemColors? testPending,
+    Color? signalExcellent,
+    Color? signalNormal,
+    Color? signalPoor,
   }) {
     return BrandThemeColors(
       primaryTintedBackground:
@@ -27,24 +60,132 @@ class BrandThemeColors extends ThemeExtension<BrandThemeColors> {
       primaryBorder: primaryBorder ?? this.primaryBorder,
       primaryHeadline: primaryHeadline ?? this.primaryHeadline,
       primaryBody: primaryBody ?? this.primaryBody,
+      adviceCritical: adviceCritical ?? this.adviceCritical,
+      adviceWarning: adviceWarning ?? this.adviceWarning,
+      adviceGood: adviceGood ?? this.adviceGood,
+      adviceInfo: adviceInfo ?? this.adviceInfo,
+      testRunning: testRunning ?? this.testRunning,
+      testComplete: testComplete ?? this.testComplete,
+      testError: testError ?? this.testError,
+      testPending: testPending ?? this.testPending,
+      signalExcellent: signalExcellent ?? this.signalExcellent,
+      signalNormal: signalNormal ?? this.signalNormal,
+      signalPoor: signalPoor ?? this.signalPoor,
     );
   }
 
   @override
   BrandThemeColors lerp(
-    covariant ThemeExtension<BrandThemeColors>? other,
+    ThemeExtension<BrandThemeColors>? other,
     double t,
   ) {
     if (other is! BrandThemeColors) {
       return this;
     }
-
     return BrandThemeColors(
       primaryTintedBackground:
           Color.lerp(primaryTintedBackground, other.primaryTintedBackground, t)!,
       primaryBorder: Color.lerp(primaryBorder, other.primaryBorder, t)!,
       primaryHeadline: Color.lerp(primaryHeadline, other.primaryHeadline, t)!,
       primaryBody: Color.lerp(primaryBody, other.primaryBody, t)!,
+      adviceCritical: adviceCritical.lerp(other.adviceCritical, t),
+      adviceWarning: adviceWarning.lerp(other.adviceWarning, t),
+      adviceGood: adviceGood.lerp(other.adviceGood, t),
+      adviceInfo: adviceInfo.lerp(other.adviceInfo, t),
+      testRunning: testRunning.lerp(other.testRunning, t),
+      testComplete: testComplete.lerp(other.testComplete, t),
+      testError: testError.lerp(other.testError, t),
+      testPending: testPending.lerp(other.testPending, t),
+      signalExcellent:
+          Color.lerp(signalExcellent, other.signalExcellent, t)!,
+      signalNormal: Color.lerp(signalNormal, other.signalNormal, t)!,
+      signalPoor: Color.lerp(signalPoor, other.signalPoor, t)!,
+    );
+  }
+}
+
+@immutable
+class AdviceColors {
+  const AdviceColors({
+    required this.background,
+    required this.icon,
+    required this.title,
+    required this.text,
+  });
+
+  final Color background;
+  final Color icon;
+  final Color title;
+  final Color text;
+
+  AdviceColors copyWith({
+    Color? background,
+    Color? icon,
+    Color? title,
+    Color? text,
+  }) {
+    return AdviceColors(
+      background: background ?? this.background,
+      icon: icon ?? this.icon,
+      title: title ?? this.title,
+      text: text ?? this.text,
+    );
+  }
+
+  AdviceColors lerp(AdviceColors other, double t) {
+    return AdviceColors(
+      background: Color.lerp(background, other.background, t)!,
+      icon: Color.lerp(icon, other.icon, t)!,
+      title: Color.lerp(title, other.title, t)!,
+      text: Color.lerp(text, other.text, t)!,
+    );
+  }
+}
+
+@immutable
+class TestItemColors {
+  const TestItemColors({
+    required this.background,
+    required this.border,
+    required this.iconContainer,
+    required this.icon,
+    required this.text,
+    required this.result,
+  });
+
+  final Color background;
+  final Color border;
+  final Color iconContainer;
+  final Color icon;
+  final Color text;
+  final Color result;
+
+  TestItemColors copyWith({
+    Color? background,
+    Color? border,
+    Color? iconContainer,
+    Color? icon,
+    Color? text,
+    Color? result,
+  }) {
+    return TestItemColors(
+      background: background ?? this.background,
+      border: border ?? this.border,
+      iconContainer: iconContainer ?? this.iconContainer,
+      icon: icon ?? this.icon,
+      text: text ?? this.text,
+      result: result ?? this.result,
+    );
+  }
+
+  TestItemColors lerp(TestItemColors other, double t) {
+    return TestItemColors(
+      background: Color.lerp(background, other.background, t)!,
+      border: Color.lerp(border, other.border, t)!,
+      iconContainer: Color.lerp(iconContainer, other.iconContainer, t)!,
+      icon: Color.lerp(icon, other.icon, t)!,
+      text: Color.lerp(text, other.text, t)!,
+      result: Color.lerp(result, other.result, t)!,
     );
   }
 }

--- a/lib/core/theme/brand_theme_colors.dart
+++ b/lib/core/theme/brand_theme_colors.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+@immutable
+class BrandThemeColors extends ThemeExtension<BrandThemeColors> {
+  const BrandThemeColors({
+    required this.primaryTintedBackground,
+    required this.primaryBorder,
+    required this.primaryHeadline,
+    required this.primaryBody,
+  });
+
+  final Color primaryTintedBackground;
+  final Color primaryBorder;
+  final Color primaryHeadline;
+  final Color primaryBody;
+
+  @override
+  BrandThemeColors copyWith({
+    Color? primaryTintedBackground,
+    Color? primaryBorder,
+    Color? primaryHeadline,
+    Color? primaryBody,
+  }) {
+    return BrandThemeColors(
+      primaryTintedBackground:
+          primaryTintedBackground ?? this.primaryTintedBackground,
+      primaryBorder: primaryBorder ?? this.primaryBorder,
+      primaryHeadline: primaryHeadline ?? this.primaryHeadline,
+      primaryBody: primaryBody ?? this.primaryBody,
+    );
+  }
+
+  @override
+  BrandThemeColors lerp(
+    covariant ThemeExtension<BrandThemeColors>? other,
+    double t,
+  ) {
+    if (other is! BrandThemeColors) {
+      return this;
+    }
+
+    return BrandThemeColors(
+      primaryTintedBackground:
+          Color.lerp(primaryTintedBackground, other.primaryTintedBackground, t)!,
+      primaryBorder: Color.lerp(primaryBorder, other.primaryBorder, t)!,
+      primaryHeadline: Color.lerp(primaryHeadline, other.primaryHeadline, t)!,
+      primaryBody: Color.lerp(primaryBody, other.primaryBody, t)!,
+    );
+  }
+}

--- a/lib/features/diagnostic/presentation/cubit/diagnostic_cubit.dart
+++ b/lib/features/diagnostic/presentation/cubit/diagnostic_cubit.dart
@@ -38,6 +38,7 @@ class DiagnosticCubit extends Cubit<DiagnosticState> {
     await _sub?.cancel();
     emit(DiagnosticState.initial().copyWith(
       globalStatus: GlobalTestStatus.running,
+      currentStage: DiagnosticStage.initializing,
     ));
 
     final eitherStream = await runDiagnosticTestUseCase(const NoParams());
@@ -76,6 +77,7 @@ class DiagnosticCubit extends Cubit<DiagnosticState> {
       globalStatus: GlobalTestStatus.error,
       errorMessage: failure.message,
       tests: updatedTests,
+      currentStage: DiagnosticStage.error,
     ));
   }
 
@@ -111,6 +113,7 @@ class DiagnosticCubit extends Cubit<DiagnosticState> {
       tests: finalTests,
       finalResults: event.results,
       clearError: true, 
+      currentStage: DiagnosticStage.completed,
     ));
   }
 
@@ -127,31 +130,44 @@ class DiagnosticCubit extends Cubit<DiagnosticState> {
     
     final testId = _stageToTestIdMap[p.stage];
     if (testId == null) {
-      emit(state.copyWith(overallProgress: overall));
+      emit(state.copyWith(
+        overallProgress: overall,
+        currentStage: p.stage,
+      ));
       return;
     }
     
-    final updatedTests = _updateTest(testId, TestStatus.running, p.message, p.progress);
+    final updatedTests = Map.of(state.tests);
+    final isCurrentComplete = p.progress >= 1.0;
+
+    updatedTests.updateAll((key, test) {
+      if (key == testId) {
+        return test;
+      }
+
+      if (test.status == TestStatus.running) {
+        final finished = test.progress >= 1.0;
+        return test.copyWith(status: finished ? TestStatus.complete : TestStatus.collecting);
+      }
+
+      return test;
+    });
+
+    final current = updatedTests[testId];
+    if (current != null) {
+      updatedTests[testId] = current.copyWith(
+        status: isCurrentComplete ? TestStatus.complete : TestStatus.running,
+        resultText: p.message,
+        progress: p.progress,
+      );
+    }
 
     emit(state.copyWith(
       overallProgress: overall,
       tests: updatedTests,
       clearError: true, 
+      currentStage: p.stage,
     ));
-  }
-
-  Map<String, TestUIState> _updateTest(String id, TestStatus status, String text, [double? progress]) {
-    final newTests = Map.of(state.tests);
-    final currentTest = newTests[id];
-    
-    if (currentTest != null) {
-      newTests[id] = currentTest.copyWith(
-        status: status,
-        resultText: text,
-        progress: progress,
-      );
-    }
-    return newTests;
   }
 
   @override

--- a/lib/features/diagnostic/presentation/cubit/diagnostic_cubit.dart
+++ b/lib/features/diagnostic/presentation/cubit/diagnostic_cubit.dart
@@ -36,9 +36,15 @@ class DiagnosticCubit extends Cubit<DiagnosticState> {
 
   Future<void> startTest() async {
     await _sub?.cancel();
-    emit(DiagnosticState.initial().copyWith(
+    emit(state.copyWith(
       globalStatus: GlobalTestStatus.running,
       currentStage: DiagnosticStage.initializing,
+      finalResults: null,
+      errorMessage: null,
+      clearError: true,
+      clearFinalResults: true,
+      tests: DiagnosticState.initial().tests,
+      overallProgress: 0.0,
     ));
 
     final eitherStream = await runDiagnosticTestUseCase(const NoParams());

--- a/lib/features/diagnostic/presentation/cubit/diagnostic_state.dart
+++ b/lib/features/diagnostic/presentation/cubit/diagnostic_state.dart
@@ -77,13 +77,14 @@ class DiagnosticState extends Equatable {
     FinalResultsEntity? finalResults,
     String? errorMessage,
     bool clearError = false, 
+    bool clearFinalResults = false,
     DiagnosticStage? currentStage,
   }) {
     return DiagnosticState(
       tests: tests ?? this.tests,
       overallProgress: overallProgress ?? this.overallProgress,
       globalStatus: globalStatus ?? this.globalStatus,
-      finalResults: finalResults ?? this.finalResults,
+      finalResults: clearFinalResults ? null : finalResults ?? this.finalResults,
       errorMessage: clearError ? null : errorMessage ?? this.errorMessage,
       currentStage: currentStage ?? this.currentStage,
     );

--- a/lib/features/diagnostic/presentation/cubit/diagnostic_state.dart
+++ b/lib/features/diagnostic/presentation/cubit/diagnostic_state.dart
@@ -43,12 +43,14 @@ class DiagnosticState extends Equatable {
   final GlobalTestStatus globalStatus;
   final FinalResultsEntity? finalResults;
   final String? errorMessage;
+  final DiagnosticStage currentStage;
 
 
   const DiagnosticState({
     required this.tests,
     required this.overallProgress,
     required this.globalStatus,
+    required this.currentStage,
     this.finalResults,
     this.errorMessage,
   });
@@ -64,6 +66,7 @@ class DiagnosticState extends Equatable {
       },
       overallProgress: 0.0,
       globalStatus: GlobalTestStatus.pending,
+      currentStage: DiagnosticStage.initializing,
     );
   }
 
@@ -74,6 +77,7 @@ class DiagnosticState extends Equatable {
     FinalResultsEntity? finalResults,
     String? errorMessage,
     bool clearError = false, 
+    DiagnosticStage? currentStage,
   }) {
     return DiagnosticState(
       tests: tests ?? this.tests,
@@ -81,6 +85,7 @@ class DiagnosticState extends Equatable {
       globalStatus: globalStatus ?? this.globalStatus,
       finalResults: finalResults ?? this.finalResults,
       errorMessage: clearError ? null : errorMessage ?? this.errorMessage,
+      currentStage: currentStage ?? this.currentStage,
     );
   }
 
@@ -91,5 +96,6 @@ class DiagnosticState extends Equatable {
         globalStatus,
         finalResults,
         errorMessage,
+        currentStage,
       ];
 }

--- a/lib/features/diagnostic/presentation/view/diagnostic_loading_screen.dart
+++ b/lib/features/diagnostic/presentation/view/diagnostic_loading_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async'; 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -5,7 +6,6 @@ import 'package:lucide_icons/lucide_icons.dart';
 import 'package:maxt_diagnostic/core/di/injection_container.dart';
 import 'package:maxt_diagnostic/features/diagnostic/presentation/cubit/diagnostic_cubit.dart';
 import 'package:maxt_diagnostic/features/diagnostic/presentation/view/widgets/pulsing_wifi_icon.dart';
-import 'package:maxt_diagnostic/features/diagnostic/presentation/view/widgets/animated_time_remaining.dart';
 
 class DiagnosticLoadingScreen extends StatelessWidget {
   const DiagnosticLoadingScreen({super.key});
@@ -28,7 +28,12 @@ class _DiagnosticLoadingView extends StatelessWidget {
       listener: (context, state) {
         if (state.finalResults != null &&
             state.globalStatus == GlobalTestStatus.complete) {
-          context.go('/results', extra: state.finalResults);
+          
+          Future.delayed(const Duration(milliseconds: 1500), () {
+            if (context.mounted) {
+              context.go('/results', extra: state.finalResults);
+            }
+          });
         }
         
         if (state.globalStatus == GlobalTestStatus.error) {
@@ -51,8 +56,69 @@ class _DiagnosticLoadingView extends StatelessWidget {
   }
 }
 
-class _DiagnosticContent extends StatelessWidget {
+class _DiagnosticContent extends StatefulWidget {
   const _DiagnosticContent();
+
+  @override
+  State<_DiagnosticContent> createState() => _DiagnosticContentState();
+}
+
+class _DiagnosticContentState extends State<_DiagnosticContent> {
+  Timer? _timer;
+  int _messageIndex = 0;
+
+  static const _statusMessages = [
+    'Inicializando diagnóstico...',
+    'Analisando sua conexão...',
+    'Verificando informações do dispositivo...',
+    'Inspecionando a rede local...',
+    'Conectando ao servidor de teste...',
+    'Executando teste de velocidade...',
+    'Analisando estabilidade da conexão...',
+    'Compilando resultados...',
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _startMessageTimer();
+  }
+
+  void _startMessageTimer() {
+    _timer?.cancel();
+    _timer = Timer.periodic(const Duration(milliseconds: 3500), (timer) {
+      final currentState = context.read<DiagnosticCubit>().state;
+      if (currentState.globalStatus != GlobalTestStatus.running) {
+        timer.cancel();
+        return;
+      }
+
+      if (mounted) {
+        setState(() {
+          _messageIndex = (_messageIndex + 1) % _statusMessages.length;
+        });
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  String _getDisplayMessage(DiagnosticState state) {
+    if (state.globalStatus == GlobalTestStatus.error) {
+      _timer?.cancel();
+      return state.errorMessage ?? 'Ocorreu um erro';
+    }
+    if (state.globalStatus == GlobalTestStatus.complete) {
+      _timer?.cancel();
+      return 'Diagnóstico concluído!';
+    }
+    
+    return _statusMessages[_messageIndex];
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -60,9 +126,7 @@ class _DiagnosticContent extends StatelessWidget {
     final progress = state.overallProgress;
     final isRunning = state.globalStatus == GlobalTestStatus.running;
     
-    const totalTime = 30;
-    final timeRemainingExact = (totalTime * (100 - progress)) / 100;
-    final timeRemaining = timeRemainingExact.floor().clamp(0, totalTime);
+    final statusMessage = _getDisplayMessage(state);
 
     return Column(
       children: [
@@ -77,12 +141,11 @@ class _DiagnosticContent extends StatelessWidget {
             ),
           ),
         ),
-        
-        const Padding(
-          padding: EdgeInsets.only(bottom: 24),
+        Padding(
+          padding: const EdgeInsets.only(bottom: 24),
           child: Column(
             children: [
-              Text(
+              const Text(
                 'Diagnóstico de Rede',
                 style: TextStyle(
                   fontSize: 28,
@@ -91,14 +154,23 @@ class _DiagnosticContent extends StatelessWidget {
                 ),
                 textAlign: TextAlign.center,
               ),
-              SizedBox(height: 8),
-              Text(
-                'Analisando sua conexão',
-                style: TextStyle(
-                  fontSize: 16,
-                  color: Color(0xFF64748B),
+              const SizedBox(height: 8),
+              
+              AnimatedSwitcher(
+                duration: const Duration(milliseconds: 300),
+                transitionBuilder: (child, animation) => FadeTransition(
+                  opacity: animation,
+                  child: child,
                 ),
-                textAlign: TextAlign.center,
+                child: Text(
+                  statusMessage,
+                  key: ValueKey<String>(statusMessage),
+                  style: const TextStyle(
+                    fontSize: 16,
+                    color: Color(0xFF64748B),
+                  ),
+                  textAlign: TextAlign.center,
+                ),
               ),
             ],
           ),
@@ -122,21 +194,15 @@ class _DiagnosticContent extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 24),
           child: Column(
             children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  const Text(
-                    'Progresso do diagnóstico',
-                    style: TextStyle(
-                      fontSize: 14,
-                      color: Color(0xFF64748B),
-                    ),
-                  ),
-                  if (isRunning)
-                    AnimatedTimeRemaining(seconds: timeRemaining),
-                ],
+              const Text(
+                'Progresso do diagnóstico',
+                style: TextStyle(
+                  fontSize: 14,
+                  color: Color(0xFF64748B),
+                ),
               ),
               const SizedBox(height: 8),
+              
               ClipRRect(
                 borderRadius: BorderRadius.circular(999),
                 child: SizedBox(
@@ -165,9 +231,7 @@ class _DiagnosticContent extends StatelessWidget {
         ),
 
         const SizedBox(height: 16),
-
         if (isRunning) const _BottomAlert(),
-        
         const SizedBox(height: 24),
       ],
     );

--- a/lib/features/diagnostic/presentation/view/diagnostic_loading_screen.dart
+++ b/lib/features/diagnostic/presentation/view/diagnostic_loading_screen.dart
@@ -13,7 +13,7 @@ class DiagnosticLoadingScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => sl<DiagnosticCubit>()..startTest(),
+      create: (_) => sl<DiagnosticCubit>(),
       child: const _DiagnosticLoadingView(),
     );
   }
@@ -47,7 +47,6 @@ class _DiagnosticLoadingView extends StatelessWidget {
         }
       },
       child: const Scaffold(
-        backgroundColor: Color(0xFFFAFAFA), 
         body: SafeArea(
           child: _DiagnosticContent(),
         ),
@@ -66,6 +65,7 @@ class _DiagnosticContent extends StatefulWidget {
 class _DiagnosticContentState extends State<_DiagnosticContent> {
   Timer? _timer;
   int _messageIndex = 0;
+  bool _hasTestStarted = false;
 
   static const _statusMessages = [
     'Inicializando diagnóstico...',
@@ -87,7 +87,14 @@ class _DiagnosticContentState extends State<_DiagnosticContent> {
   void _startMessageTimer() {
     _timer?.cancel();
     _timer = Timer.periodic(const Duration(milliseconds: 3500), (timer) {
-      final currentState = context.read<DiagnosticCubit>().state;
+      var currentState = context.read<DiagnosticCubit>().state;
+
+      if (!_hasTestStarted && mounted) {
+        _hasTestStarted = true;
+        context.read<DiagnosticCubit>().startTest();
+        currentState = context.read<DiagnosticCubit>().state;
+      }
+
       if (currentState.globalStatus != GlobalTestStatus.running) {
         timer.cancel();
         return;
@@ -115,6 +122,10 @@ class _DiagnosticContentState extends State<_DiagnosticContent> {
     if (state.globalStatus == GlobalTestStatus.complete) {
       _timer?.cancel();
       return 'Diagnóstico concluído!';
+    }
+
+    if (!_hasTestStarted || state.globalStatus == GlobalTestStatus.pending) {
+      return 'Inicializando diagnóstico...';
     }
     
     return _statusMessages[_messageIndex];

--- a/lib/features/diagnostic/presentation/view/diagnostic_loading_screen.dart
+++ b/lib/features/diagnostic/presentation/view/diagnostic_loading_screen.dart
@@ -46,8 +46,13 @@ class _DiagnosticLoadingView extends StatelessWidget {
           );
         }
       },
-      child: const Scaffold(
-        body: SafeArea(
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('MAX DIAGNÓSTICO'),
+          automaticallyImplyLeading: false,
+        ),
+        body: const SafeArea(
+          top: false,
           child: _DiagnosticContent(),
         ),
       ),
@@ -67,7 +72,7 @@ class _DiagnosticContentState extends State<_DiagnosticContent> {
   int _messageIndex = 0;
   bool _hasTestStarted = false;
 
-  static const _statusMessages = [
+  static const List<String> _statusMessages = [
     'Inicializando diagnóstico...',
     'Analisando sua conexão...',
     'Verificando informações do dispositivo...',
@@ -141,19 +146,8 @@ class _DiagnosticContentState extends State<_DiagnosticContent> {
 
     return Column(
       children: [
-        const Padding(
-          padding: EdgeInsets.only(top: 40, bottom: 24),
-          child: Text(
-            'MAX INTERNET',
-            style: TextStyle(
-              fontSize: 24,
-              fontWeight: FontWeight.bold,
-              color: Color(0xFF334155),
-            ),
-          ),
-        ),
         Padding(
-          padding: const EdgeInsets.only(bottom: 24),
+          padding: const EdgeInsets.only(top: 40, bottom: 24),
           child: Column(
             children: [
               const Text(

--- a/lib/features/diagnostic/presentation/view/diagnostic_loading_screen.dart
+++ b/lib/features/diagnostic/presentation/view/diagnostic_loading_screen.dart
@@ -1,4 +1,4 @@
-import 'dart:async'; 
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -69,8 +69,10 @@ class _DiagnosticContent extends StatefulWidget {
 
 class _DiagnosticContentState extends State<_DiagnosticContent> {
   Timer? _timer;
+  Timer? _uiReadyTimer;
   int _messageIndex = 0;
   bool _hasTestStarted = false;
+  bool _isUiReady = false;
 
   static const List<String> _statusMessages = [
     'Inicializando diagnóstico...',
@@ -86,7 +88,17 @@ class _DiagnosticContentState extends State<_DiagnosticContent> {
   @override
   void initState() {
     super.initState();
-    _startMessageTimer();
+    _uiReadyTimer = Timer(const Duration(milliseconds: 300), () {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _isUiReady = true;
+      });
+
+      _startMessageTimer();
+    });
   }
 
   void _startMessageTimer() {
@@ -116,6 +128,7 @@ class _DiagnosticContentState extends State<_DiagnosticContent> {
   @override
   void dispose() {
     _timer?.cancel();
+    _uiReadyTimer?.cancel();
     super.dispose();
   }
 
@@ -140,105 +153,133 @@ class _DiagnosticContentState extends State<_DiagnosticContent> {
   Widget build(BuildContext context) {
     final state = context.watch<DiagnosticCubit>().state;
     final progress = state.overallProgress;
-    final isRunning = state.globalStatus == GlobalTestStatus.running;
     
     final statusMessage = _getDisplayMessage(state);
 
-    return Column(
-      children: [
-        Padding(
-          padding: const EdgeInsets.only(top: 40, bottom: 24),
-          child: Column(
-            children: [
-              const Text(
-                'Diagnóstico de Rede',
-                style: TextStyle(
-                  fontSize: 28,
-                  fontWeight: FontWeight.bold,
-                  color: Color(0xFF334155),
-                ),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 8),
-              
-              AnimatedSwitcher(
-                duration: const Duration(milliseconds: 300),
-                transitionBuilder: (child, animation) => FadeTransition(
-                  opacity: animation,
-                  child: child,
-                ),
-                child: Text(
-                  statusMessage,
-                  key: ValueKey<String>(statusMessage),
-                  style: const TextStyle(
-                    fontSize: 16,
-                    color: Color(0xFF64748B),
-                  ),
-                  textAlign: TextAlign.center,
-                ),
-              ),
-            ],
-          ),
-        ),
-
-        const Expanded(
-          child: Padding(
-            padding: EdgeInsets.symmetric(horizontal: 24),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 400),
+      child: !_isUiReady
+          ? const Center(
+              key: ValueKey('loading'),
+              child: CircularProgressIndicator(),
+            )
+          : Column(
+              key: const ValueKey('mainUI'),
               children: [
-                RepaintBoundary(
-                  child: PulsingWifiIcon(),
+                Padding(
+                  padding: const EdgeInsets.only(top: 40, bottom: 24),
+                  child: Column(
+                    children: [
+                      const Text(
+                        'Diagnóstico de Rede',
+                        style: TextStyle(
+                          fontSize: 28,
+                          fontWeight: FontWeight.bold,
+                          color: Color(0xFF334155),
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 8),
+                      AnimatedSwitcher(
+                        duration: const Duration(milliseconds: 300),
+                        transitionBuilder: (child, animation) => FadeTransition(
+                          opacity: animation,
+                          child: child,
+                        ),
+                        child: Text(
+                          statusMessage,
+                          key: ValueKey<String>(statusMessage),
+                          style: const TextStyle(
+                            fontSize: 16,
+                            color: Color(0xFF64748B),
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
+                const Expanded(
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 24),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        RepaintBoundary(
+                          child: PulsingWifiIcon(),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: Column(
+                    children: [
+                      const Text(
+                        'Progresso do diagnóstico',
+                        style: TextStyle(
+                          fontSize: 14,
+                          color: Color(0xFF64748B),
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      _buildProgressBar(state, progress),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 16),
+                AnimatedOpacity(
+                  duration: const Duration(milliseconds: 300),
+                  opacity: state.globalStatus != GlobalTestStatus.error ? 1.0 : 0.0,
+                  child: const _BottomAlert(),
+                ),
+                const SizedBox(height: 24),
               ],
             ),
-          ),
-        ),
+    );
+  }
 
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: Column(
-            children: [
-              const Text(
-                'Progresso do diagnóstico',
-                style: TextStyle(
-                  fontSize: 14,
-                  color: Color(0xFF64748B),
-                ),
-              ),
-              const SizedBox(height: 8),
-              
-              ClipRRect(
-                borderRadius: BorderRadius.circular(999),
-                child: SizedBox(
-                  height: 8,
-                  child: TweenAnimationBuilder<double>(
-                    duration: const Duration(milliseconds: 300),
-                    curve: Curves.easeOutCubic,
-                    tween: Tween<double>(
-                      begin: 0,
-                      end: progress / 100,
-                    ),
-                    builder: (context, value, child) {
-                      return LinearProgressIndicator(
-                        value: value,
-                        backgroundColor: const Color(0xFFE2E8F0), 
-                        valueColor: const AlwaysStoppedAnimation<Color>(
-                          Color(0xFF3B82F6),
-                        ),
-                      );
-                    },
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
+  Widget _buildProgressBar(DiagnosticState state, double progress) {
+    final progressColor = Theme.of(context).colorScheme.primary;
+    final trackColor = Colors.grey.shade200;
 
-        const SizedBox(height: 16),
-        if (isRunning) const _BottomAlert(),
-        const SizedBox(height: 24),
-      ],
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(999),
+      child: SizedBox(
+        height: 8,
+        child: switch (state.globalStatus) {
+          GlobalTestStatus.pending => LinearProgressIndicator(
+              valueColor: AlwaysStoppedAnimation<Color>(progressColor),
+              backgroundColor: trackColor,
+            ),
+          GlobalTestStatus.running => TweenAnimationBuilder<double>(
+              duration: const Duration(milliseconds: 300),
+              curve: Curves.easeOutCubic,
+              tween: Tween<double>(
+                begin: 0,
+                end: progress / 100,
+              ),
+              builder: (context, value, child) {
+                return LinearProgressIndicator(
+                  value: value,
+                  backgroundColor: trackColor,
+                  valueColor: AlwaysStoppedAnimation<Color>(progressColor),
+                );
+              },
+            ),
+          GlobalTestStatus.complete => LinearProgressIndicator(
+              value: 1.0,
+              backgroundColor: trackColor,
+              valueColor: AlwaysStoppedAnimation<Color>(progressColor),
+            ),
+          GlobalTestStatus.error => LinearProgressIndicator(
+              value: progress / 100,
+              backgroundColor: trackColor,
+              valueColor: const AlwaysStoppedAnimation<Color>(Colors.red),
+            ),
+        },
+      ),
     );
   }
 }

--- a/lib/features/diagnostic/presentation/view/widgets/pulsing_wifi_icon.dart
+++ b/lib/features/diagnostic/presentation/view/widgets/pulsing_wifi_icon.dart
@@ -43,6 +43,12 @@ class _PulsingWifiIconState extends State<PulsingWifiIcon>
 
   @override
   Widget build(BuildContext context) {
+    final primaryColor = Theme.of(context).colorScheme.primary;
+    final darkerPrimary = Color.alphaBlend(
+      Colors.black.withValues(alpha: 0.2),
+      primaryColor,
+    );
+
     return FadeTransition(
       opacity: _fadeController,
       child: SizedBox(
@@ -53,7 +59,7 @@ class _PulsingWifiIconState extends State<PulsingWifiIcon>
           children: [
             _PulsingRing(
               size: 256,
-              color: const Color(0xFF3B82F6).withValues(alpha: 0.1),
+              color: primaryColor.withValues(alpha: 0.1),
               duration: const Duration(milliseconds: 1500),
             ),
 
@@ -65,7 +71,7 @@ class _PulsingWifiIconState extends State<PulsingWifiIcon>
                   height: 224,
                   decoration: BoxDecoration(
                     shape: BoxShape.circle,
-                    color: const Color(0xFF3B82F6).withValues(
+                    color: primaryColor.withValues(
                       alpha: 0.2 * (1 - _pulseController.value * 0.5),
                     ),
                   ),
@@ -75,7 +81,7 @@ class _PulsingWifiIconState extends State<PulsingWifiIcon>
 
             _PulsingRing(
               size: 192,
-              color: const Color(0xFF3B82F6).withValues(alpha: 0.3),
+              color: primaryColor.withValues(alpha: 0.3),
               duration: const Duration(milliseconds: 1500),
               delay: const Duration(milliseconds: 500),
             ),
@@ -84,17 +90,17 @@ class _PulsingWifiIconState extends State<PulsingWifiIcon>
               height: 144,
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
-                gradient: const LinearGradient(
+                gradient: LinearGradient(
                   begin: Alignment.topLeft,
                   end: Alignment.bottomRight,
                   colors: [
-                    Color(0xFF3B82F6),
-                    Color(0xFF2563EB), 
+                    primaryColor,
+                    darkerPrimary,
                   ],
                 ),
                 boxShadow: [
                   BoxShadow(
-                    color: const Color(0xFF3B82F6).withValues(alpha: 0.15),
+                    color: primaryColor.withValues(alpha: 0.15),
                     blurRadius: 24,
                     spreadRadius: 4,
                   ),
@@ -223,6 +229,8 @@ class _RotatingDot extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final primaryColor = Theme.of(context).colorScheme.primary;
+
     return AnimatedBuilder(
       animation: controller,
       builder: (context, child) {
@@ -241,10 +249,11 @@ class _RotatingDot extends StatelessWidget {
             height: size,
             decoration: BoxDecoration(
               shape: BoxShape.circle,
-              color: const Color(0xFF3B82F6).withValues(alpha: opacity),
+              color: primaryColor.withValues(alpha: opacity),
               boxShadow: [
                 BoxShadow(
-                  color: const Color(0xFF3B82F6).withValues(alpha: 0.8 * opacity),
+                  color:
+                      primaryColor.withValues(alpha: 0.8 * opacity),
                   blurRadius: 10,
                   spreadRadius: 2,
                 ),

--- a/lib/features/diagnostic/presentation/view/widgets/test_item_card.dart
+++ b/lib/features/diagnostic/presentation/view/widgets/test_item_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:lucide_icons/lucide_icons.dart';
 import 'package:maxt_diagnostic/features/diagnostic/presentation/cubit/diagnostic_cubit.dart';
+import 'package:maxt_diagnostic/core/theme/brand_theme_colors.dart';
 
 class TestItemCard extends StatefulWidget {
   final TestUIState test;
@@ -32,14 +33,16 @@ class _TestItemCardState extends State<TestItemCard>
 
   @override
   Widget build(BuildContext context) {
-    final theme = _getTheme(widget.test.status);
+    final brandColors =
+        Theme.of(context).extension<BrandThemeColors>()!;
+    final testColors = _colorsForStatus(brandColors, widget.test.status);
 
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: theme.backgroundColor,
+        color: testColors.background,
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: theme.borderColor),
+        border: Border.all(color: testColors.border),
       ),
       child: Row(
         children: [
@@ -47,10 +50,10 @@ class _TestItemCardState extends State<TestItemCard>
             width: 40,
             height: 40,
             decoration: BoxDecoration(
-              color: theme.iconContainerColor,
+              color: testColors.iconContainer,
               shape: BoxShape.circle,
             ),
-            child: _getIcon(widget.test.status, theme.iconColor),
+            child: _getIcon(widget.test.status, testColors.icon),
           ),
           const SizedBox(width: 12),
           Expanded(
@@ -62,25 +65,21 @@ class _TestItemCardState extends State<TestItemCard>
                   style: TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w600,
-                    color: theme.textColor,
+                    color: testColors.text,
                   ),
                 ),
-                if (widget.test.status != TestStatus.pending)
-                  Text(
-                    widget.test.resultText ?? 'Aguardando...',
-                    style: TextStyle(
-                      fontSize: 14,
-                      color: theme.resultColor,
-                    ),
-                  )
-                else
-                  const Text(
-                    'Aguardando...',
-                    style: TextStyle(
-                        fontSize: 14,
-                        color: Colors.grey,
-                        fontStyle: FontStyle.italic),
+                Text(
+                  widget.test.status != TestStatus.pending
+                      ? widget.test.resultText ?? 'Aguardando...'
+                      : 'Aguardando...',
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: testColors.result,
+                    fontStyle: widget.test.status == TestStatus.pending
+                        ? FontStyle.italic
+                        : FontStyle.normal,
                   ),
+                ),
               ],
             ),
           ),
@@ -120,63 +119,20 @@ class _TestItemCardState extends State<TestItemCard>
     return Icon(iconData, color: color);
   }
 
-  _TestTheme _getTheme(TestStatus status) {
+  TestItemColors _colorsForStatus(
+    BrandThemeColors colors,
+    TestStatus status,
+  ) {
     switch (status) {
       case TestStatus.running:
       case TestStatus.collecting:
-        return _TestTheme(
-          backgroundColor: const Color(0xFFEFF6FF),
-          borderColor: const Color(0xFF4D89FF),
-          iconContainerColor: const Color(0xFFDBEAFE),
-          iconColor: const Color(0xFF4D89FF),
-          textColor: const Color(0xFF2563EB),
-          resultColor: const Color(0xFF2563EB),
-        );
+        return colors.testRunning;
       case TestStatus.complete:
-        return _TestTheme(
-          backgroundColor: const Color(0xFFF0FDF4),
-          borderColor: const Color(0xFF10B981),
-          iconContainerColor: const Color(0xFFD1FAE5),
-          iconColor: const Color(0xFF10B981),
-          textColor: const Color(0xFF059669),
-          resultColor: const Color(0xFF047857),
-        );
+        return colors.testComplete;
       case TestStatus.error:
-        return _TestTheme(
-          backgroundColor: const Color(0xFFFEF2F2),
-          borderColor: const Color(0xFFEF4444),
-          iconContainerColor: const Color(0xFFFEE2E2),
-          iconColor: const Color(0xFFEF4444),
-          textColor: const Color(0xFFDC2626),
-          resultColor: const Color(0xFFB91C1C),
-        );
+        return colors.testError;
       case TestStatus.pending:
-        return _TestTheme(
-          backgroundColor: Colors.white,
-          borderColor: const Color(0xFFE5E7EB),
-          iconContainerColor: const Color(0xFFF1F5F9),
-          iconColor: const Color(0xFF94A3B8),
-          textColor: const Color(0xFF64748B),
-          resultColor: Colors.grey,
-        );
+        return colors.testPending;
     }
   }
-}
-
-class _TestTheme {
-  final Color backgroundColor;
-  final Color borderColor;
-  final Color iconContainerColor;
-  final Color iconColor;
-  final Color textColor;
-  final Color resultColor;
-
-  _TestTheme({
-    required this.backgroundColor,
-    required this.borderColor,
-    required this.iconContainerColor,
-    required this.iconColor,
-    required this.textColor,
-    required this.resultColor,
-  });
 }

--- a/lib/features/home/presentation/view/home_screen.dart
+++ b/lib/features/home/presentation/view/home_screen.dart
@@ -140,149 +140,139 @@ class HomeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('MAX DIAGNÓSTICO'),
-        centerTitle: false,
+        centerTitle: true,
       ),
       backgroundColor: const Color(0xFFF9FAFB),
-      body: SafeArea(
-        top: false,
+      body: BlocBuilder<HomeCubit, HomeState>(
+        builder: (context, state) {
+          if (state is HomeInitial) {
+            context.read<HomeCubit>().fetchInitialInfo();
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (state is HomeLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (state is HomeError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24.0),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(
+                      'Erro ao carregar: ${state.message}',
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 20),
+                    ElevatedButton(
+                      onPressed: () =>
+                          context.read<HomeCubit>().fetchInitialInfo(),
+                      child: const Text('Tentar Novamente'),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+
+          if (state is HomePermissionDenied) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24.0),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(
+                      state.message,
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 12),
+                    ElevatedButton(
+                      onPressed: () async {
+                        await context
+                            .read<HomeCubit>()
+                            .requestLocationPermission();
+                      },
+                      child: const Text('Conceder permissões'),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+
+          if (state is HomeLoaded) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              context.read<HomeCubit>().startAutoRefresh();
+            });
+
+            return ListView(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(top: 8.0, bottom: 12.0),
+                  child: Text(
+                    'Status da Rede',
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: theme.colorScheme.onSurface.withValues(
+                        alpha: 0.9,
+                      ),
+                    ),
+                  ),
+                ),
+                NetworkInfoCard(networkInfo: state.networkInfo),
+                const SizedBox(height: 24),
+                const QuickTipsCard(),
+                const SizedBox(height: 24),
+                const RotatingInfoCard(),
+                const SizedBox(height: 32),
+              ],
+            );
+          }
+
+          return const Center(child: Text('Estado não reconhecido.'));
+        },
+      ),
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
         child: BlocBuilder<HomeCubit, HomeState>(
           builder: (context, state) {
-            if (state is HomeInitial) {
-              context.read<HomeCubit>().fetchInitialInfo();
-              return const Center(child: CircularProgressIndicator());
-            }
-
-            if (state is HomeLoading) {
-              return const Center(child: CircularProgressIndicator());
-            }
-
-            if (state is HomeError) {
-              return Center(
-                child: Padding(
-                  padding: const EdgeInsets.all(24.0),
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text(
-                        'Erro ao carregar: ${state.message}',
-                        textAlign: TextAlign.center,
-                      ),
-                      const SizedBox(height: 20),
-                      ElevatedButton(
-                        onPressed: () =>
-                            context.read<HomeCubit>().fetchInitialInfo(),
-                        child: const Text('Tentar Novamente'),
-                      ),
-                    ],
-                  ),
-                ),
+            if (state is! HomeLoaded) {
+              return DiagnosticButton(
+                isEnabled: false,
+                onPressed: () => context.go('/diagnostic'),
               );
             }
 
-            if (state is HomePermissionDenied) {
-              return Center(
-                child: Padding(
-                  padding: const EdgeInsets.all(24.0),
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text(
-                        state.message,
-                        textAlign: TextAlign.center,
-                      ),
-                      const SizedBox(height: 12),
-                      ElevatedButton(
-                        onPressed: () async {
-                          await context
-                              .read<HomeCubit>()
-                              .requestLocationPermission();
-                        },
-                        child: const Text('Conceder permissões'),
-                      ),
-                    ],
-                  ),
-                ),
-              );
-            }
+            final config = di.sl<AppConfig>();
+            final noConnection =
+                state.networkInfo.connectionType.toLowerCase() == 'none';
+            final isServerReachable = state.isSpeedTestServerReachable;
+            final canStart = !noConnection &&
+                isServerReachable &&
+                config.isSignalExcellent(state.networkInfo.wifiSignalStrength);
 
-            if (state is HomeLoaded) {
-              WidgetsBinding.instance.addPostFrameCallback((_) {
-                context.read<HomeCubit>().startAutoRefresh();
-              });
-              final config = di.sl<AppConfig>();
-              final noConnection =
-                  state.networkInfo.connectionType.toLowerCase() == 'none';
-              
-              final isServerReachable = state.isSpeedTestServerReachable;
-
-              final canStart = !noConnection &&
-                  isServerReachable && 
-                  config
-                      .isSignalExcellent(state.networkInfo.wifiSignalStrength);
-              return Column(
-                children: [
-                  const Padding(
-                    padding: EdgeInsets.only(top: 40, bottom: 24),
-                    child: Column(
-                      children: [
-                        Text('MAX DIAGNÓSTICO',
-                            style: TextStyle(
-                                fontSize: 24, fontWeight: FontWeight.bold)),
-                        SizedBox(height: 8),
-                        Text('Status da Rede',
-                            style:
-                                TextStyle(fontSize: 16, color: Color(0xFF64748B))),
-                      ],
-                    ),
-                  ),
-                  Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                      child: SingleChildScrollView(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.stretch,
-                          children: [
-                            NetworkInfoCard(networkInfo: state.networkInfo),
-                            const SizedBox(height: 16),
-                            const QuickTipsCard(),
-                            const SizedBox(height: 16),
-                            const RotatingInfoCard(),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.all(16.0),
-                    child: SizedBox(
-                      width: double.infinity,
-                      height: 56,
-                      child: DiagnosticButton(
-                        isEnabled: canStart,
-                        onPressed: () {
-                          context.go('/diagnostic');
-                        },
-                        onBlockedTap: () {
-                          _showBlockedStartSheet(
-                            context,
-                            noConnection: noConnection,
-                            isServerUnreachable: !isServerReachable,
-                            currentDbm: state.networkInfo.wifiSignalStrength,
-                            excellentThreshold:
-                                config.signalExcellentThresholdDbm,
-                          );
-                        },
-                      ),
-                    ),
-                  ),
-                ],
-              );
-            }
-
-            return const Center(child: Text('Estado não reconhecido.'));
+            return DiagnosticButton(
+              isEnabled: canStart,
+              onPressed: () => context.go('/diagnostic'),
+              onBlockedTap: () {
+                _showBlockedStartSheet(
+                  context,
+                  noConnection: noConnection,
+                  isServerUnreachable: !isServerReachable,
+                  currentDbm: state.networkInfo.wifiSignalStrength,
+                  excellentThreshold: config.signalExcellentThresholdDbm,
+                );
+              },
+            );
           },
         ),
       ),

--- a/lib/features/home/presentation/view/home_screen.dart
+++ b/lib/features/home/presentation/view/home_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:maxt_diagnostic/features/home/presentation/cubit/home_cubit.dart';
 import 'package:maxt_diagnostic/core/config/app_config.dart';
 import 'package:maxt_diagnostic/core/di/injection_container.dart' as di;
+import 'package:maxt_diagnostic/core/theme/brand_theme_colors.dart';
 import 'package:maxt_diagnostic/features/home/presentation/view/widgets/diagnostic_button.dart';
 import 'package:maxt_diagnostic/features/home/presentation/view/widgets/network_info_card.dart';
 import 'package:maxt_diagnostic/features/home/presentation/view/widgets/quick_tips_card.dart';
@@ -19,19 +20,23 @@ class HomeScreen extends StatelessWidget {
     required int? currentDbm,
     required int excellentThreshold,
   }) {
-    Color qualityColor(SignalQuality q) {
-      switch (q) {
-        case SignalQuality.excellent:
-          return const Color(0xFF16A34A);
-        case SignalQuality.normal:
-          return const Color(0xFFD97706);
-        case SignalQuality.poor:
-          return const Color(0xFFDC2626);
-      }
-    }
+    final theme = Theme.of(context);
+    final brandColors = theme.extension<BrandThemeColors>()!;
 
-  final config = di.sl<AppConfig>();
+    final config = di.sl<AppConfig>();
     final quality = config.getSignalQuality(currentDbm);
+    final Color signalColor;
+    switch (quality) {
+      case SignalQuality.excellent:
+        signalColor = brandColors.signalExcellent;
+        break;
+      case SignalQuality.normal:
+        signalColor = brandColors.signalNormal;
+        break;
+      case SignalQuality.poor:
+        signalColor = brandColors.signalPoor;
+        break;
+    }
     double progress;
     if (currentDbm == null) {
       progress = 0;
@@ -81,13 +86,13 @@ class HomeScreen extends StatelessWidget {
                       padding: const EdgeInsets.symmetric(
                           horizontal: 8, vertical: 4),
                       decoration: BoxDecoration(
-                        color: qualityColor(quality).withValues(alpha: 0.12),
+                        color: signalColor.withValues(alpha: 0.12),
                         borderRadius: BorderRadius.circular(999),
                       ),
                       child: Text(
                         config.qualityLabel(quality),
                         style: TextStyle(
-                          color: qualityColor(quality),
+                          color: signalColor,
                           fontWeight: FontWeight.w600,
                         ),
                       ),
@@ -102,7 +107,7 @@ class HomeScreen extends StatelessWidget {
                   value: progress,
                   minHeight: 8,
                   backgroundColor: Colors.grey.shade200,
-                  color: qualityColor(quality),
+                  color: signalColor,
                 ),
                 const SizedBox(height: 8),
                 Text(

--- a/lib/features/home/presentation/view/home_screen.dart
+++ b/lib/features/home/presentation/view/home_screen.dart
@@ -218,12 +218,15 @@ class HomeScreen extends StatelessWidget {
               children: [
                 Padding(
                   padding: const EdgeInsets.only(top: 8.0, bottom: 12.0),
-                  child: Text(
-                    'Status da Rede',
-                    style: theme.textTheme.titleLarge?.copyWith(
-                      fontWeight: FontWeight.w600,
-                      color: theme.colorScheme.onSurface.withValues(
-                        alpha: 0.9,
+                  child: Center(
+                    child: Text(
+                      'Status da Rede',
+                      textAlign: TextAlign.center,
+                      style: theme.textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: theme.colorScheme.onSurface.withValues(
+                          alpha: 0.9,
+                        ),
                       ),
                     ),
                   ),

--- a/lib/features/home/presentation/view/home_screen.dart
+++ b/lib/features/home/presentation/view/home_screen.dart
@@ -141,8 +141,13 @@ class HomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(
+        title: const Text('MAX DIAGNÓSTICO'),
+        centerTitle: false,
+      ),
       backgroundColor: const Color(0xFFF9FAFB),
       body: SafeArea(
+        top: false,
         child: BlocBuilder<HomeCubit, HomeState>(
           builder: (context, state) {
             if (state is HomeInitial) {
@@ -223,12 +228,13 @@ class HomeScreen extends StatelessWidget {
                     padding: EdgeInsets.only(top: 40, bottom: 24),
                     child: Column(
                       children: [
-                        Text('MAX INTERNET',
+                        Text('MAX DIAGNÓSTICO',
                             style: TextStyle(
                                 fontSize: 24, fontWeight: FontWeight.bold)),
                         SizedBox(height: 8),
                         Text('Status da Rede',
-                            style: TextStyle(fontSize: 16, color: Color(0xFF64748B))),
+                            style:
+                                TextStyle(fontSize: 16, color: Color(0xFF64748B))),
                       ],
                     ),
                   ),

--- a/lib/features/home/presentation/view/widgets/diagnostic_button.dart
+++ b/lib/features/home/presentation/view/widgets/diagnostic_button.dart
@@ -17,17 +17,22 @@ class DiagnosticButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
     return ElevatedButton(
       style: ElevatedButton.styleFrom(
         backgroundColor:
-            isEnabled ? const Color(0xFF4D89FF) : Colors.grey.shade300,
-        foregroundColor: isEnabled ? Colors.white : Colors.grey.shade600,
+            isEnabled ? colorScheme.primary : Colors.grey.shade300,
+        foregroundColor:
+            isEnabled ? colorScheme.onPrimary : Colors.grey.shade600,
         padding: const EdgeInsets.symmetric(vertical: 18, horizontal: 12),
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(8),
         ),
         elevation: isEnabled ? 4 : 0,
-        shadowColor: const Color(0xFF4D89FF).withAlpha(77),
+        shadowColor:
+            isEnabled ? colorScheme.primary.withAlpha(77) : Colors.transparent,
       ),
       onPressed: () {
         if (isEnabled) {

--- a/lib/features/home/presentation/view/widgets/network_info_card.dart
+++ b/lib/features/home/presentation/view/widgets/network_info_card.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:lucide_icons/lucide_icons.dart';
+import 'package:maxt_diagnostic/core/config/app_config.dart';
+import 'package:maxt_diagnostic/core/di/injection_container.dart' as di;
 import 'package:maxt_diagnostic/domain/entities/final_results_entity.dart';
 import 'package:maxt_diagnostic/features/home/presentation/view/widgets/signal_strength_text.dart';
 
@@ -12,6 +14,7 @@ class NetworkInfoCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final primaryColor = theme.colorScheme.primary;
+  final config = di.sl<AppConfig>();
 
     final isConnected = networkInfo.connectionType.toLowerCase() != 'none';
     final titleText = () {
@@ -23,6 +26,7 @@ class NetworkInfoCard extends StatelessWidget {
     }();
     final signalDbm = networkInfo.wifiSignalStrength;
     final frequency = networkInfo.wifiFrequency;
+  final quality = config.getSignalQuality(signalDbm);
 
     return Card(
       elevation: 2,
@@ -63,7 +67,7 @@ class NetworkInfoCard extends StatelessWidget {
               ),
               const SizedBox(height: 10),
               SignalStrengthText(
-                strengthInDbm: signalDbm,
+                quality: quality,
               ),
             ] else ...[
               const Text(

--- a/lib/features/home/presentation/view/widgets/network_info_card.dart
+++ b/lib/features/home/presentation/view/widgets/network_info_card.dart
@@ -14,7 +14,7 @@ class NetworkInfoCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final primaryColor = theme.colorScheme.primary;
-  final config = di.sl<AppConfig>();
+    final config = di.sl<AppConfig>();
 
     final isConnected = networkInfo.connectionType.toLowerCase() != 'none';
     final titleText = () {
@@ -26,12 +26,9 @@ class NetworkInfoCard extends StatelessWidget {
     }();
     final signalDbm = networkInfo.wifiSignalStrength;
     final frequency = networkInfo.wifiFrequency;
-  final quality = config.getSignalQuality(signalDbm);
+    final quality = config.getSignalQuality(signalDbm);
 
     return Card(
-      elevation: 2,
-      shadowColor: Colors.black12,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(

--- a/lib/features/home/presentation/view/widgets/network_info_card.dart
+++ b/lib/features/home/presentation/view/widgets/network_info_card.dart
@@ -10,6 +10,9 @@ class NetworkInfoCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final primaryColor = theme.colorScheme.primary;
+
     final isConnected = networkInfo.connectionType.toLowerCase() != 'none';
     final titleText = () {
       if (!isConnected) return 'Sem conexão';
@@ -34,15 +37,15 @@ class NetworkInfoCard extends StatelessWidget {
               children: [
                 Icon(
                   LucideIcons.wifi,
-                  color: isConnected ? const Color(0xFF4D89FF) : Colors.grey,
+                  color: isConnected ? primaryColor : Colors.grey,
                 ),
                 const SizedBox(width: 8),
                 Text(
                   titleText,
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 20,
                     fontWeight: FontWeight.w600,
-                    color: Color(0xFF1F2937),
+                    color: theme.colorScheme.onSurface,
                   ),
                 ),
               ],

--- a/lib/features/home/presentation/view/widgets/quick_tips_card.dart
+++ b/lib/features/home/presentation/view/widgets/quick_tips_card.dart
@@ -11,9 +11,6 @@ class QuickTipsCard extends StatelessWidget {
     final tips = di.sl<AppConfig>().quickTips;
 
     return Card(
-      elevation: 2,
-      shadowColor: Colors.black12,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       child: Padding(
         padding: const EdgeInsets.all(20.0),
         child: Column(

--- a/lib/features/home/presentation/view/widgets/rotating_info_card.dart
+++ b/lib/features/home/presentation/view/widgets/rotating_info_card.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import '../../../../../l10n/app_localizations.dart';
 import 'package:lucide_icons/lucide_icons.dart';
+import 'package:maxt_diagnostic/core/theme/brand_theme_colors.dart';
 
 class RotatingInfoCard extends StatefulWidget {
   const RotatingInfoCard({super.key});
@@ -66,28 +67,13 @@ class _RotatingInfoCardState extends State<RotatingInfoCard>
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final primaryColor = theme.colorScheme.primary;
-    final tintedBackground = Color.alphaBlend(
-      primaryColor.withValues(alpha: 0.08),
-      theme.colorScheme.surface,
-    );
-    final borderColor = primaryColor.withValues(alpha: 0.2);
-    final headlineColor = Color.alphaBlend(
-      Colors.black.withValues(alpha: 0.2),
-      primaryColor,
-    );
-    final bodyColor = Color.alphaBlend(
-      Colors.white.withValues(alpha: 0.1),
-      primaryColor,
-    );
+    final brandColors = theme.extension<BrandThemeColors>()!;
 
     return Card(
-      elevation: 2,
-      color: tintedBackground,
-      shadowColor: Colors.black12,
+      color: brandColors.primaryTintedBackground,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(16),
-        side: BorderSide(color: borderColor),
+        side: BorderSide(color: brandColors.primaryBorder),
       ),
       child: Padding(
         padding: const EdgeInsets.all(20.0),
@@ -95,14 +81,14 @@ class _RotatingInfoCardState extends State<RotatingInfoCard>
           children: [
             Row(
               children: [
-                Icon(LucideIcons.info, color: primaryColor),
+                Icon(LucideIcons.info, color: theme.colorScheme.primary),
                 const SizedBox(width: 8),
                 Text(
                   AppLocalizations.of(context)!.stay_informed,
                   style: TextStyle(
                     fontSize: 18,
                     fontWeight: FontWeight.w600,
-                    color: headlineColor,
+                    color: brandColors.primaryHeadline,
                   ),
                 ),
               ],
@@ -117,7 +103,7 @@ class _RotatingInfoCardState extends State<RotatingInfoCard>
                   textAlign: TextAlign.center,
                   style: TextStyle(
                     fontSize: 16,
-                    color: bodyColor,
+                    color: brandColors.primaryBody,
                     height: 1.5,
                   ),
                 ),

--- a/lib/features/home/presentation/view/widgets/rotating_info_card.dart
+++ b/lib/features/home/presentation/view/widgets/rotating_info_card.dart
@@ -71,10 +71,6 @@ class _RotatingInfoCardState extends State<RotatingInfoCard>
 
     return Card(
       color: brandColors.primaryTintedBackground,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(16),
-        side: BorderSide(color: brandColors.primaryBorder),
-      ),
       child: Padding(
         padding: const EdgeInsets.all(20.0),
         child: Column(

--- a/lib/features/home/presentation/view/widgets/rotating_info_card.dart
+++ b/lib/features/home/presentation/view/widgets/rotating_info_card.dart
@@ -65,13 +65,29 @@ class _RotatingInfoCardState extends State<RotatingInfoCard>
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final primaryColor = theme.colorScheme.primary;
+    final tintedBackground = Color.alphaBlend(
+      primaryColor.withValues(alpha: 0.08),
+      theme.colorScheme.surface,
+    );
+    final borderColor = primaryColor.withValues(alpha: 0.2);
+    final headlineColor = Color.alphaBlend(
+      Colors.black.withValues(alpha: 0.2),
+      primaryColor,
+    );
+    final bodyColor = Color.alphaBlend(
+      Colors.white.withValues(alpha: 0.1),
+      primaryColor,
+    );
+
     return Card(
       elevation: 2,
-      color: const Color(0xFFEFF6FF),
+      color: tintedBackground,
       shadowColor: Colors.black12,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(16),
-        side: const BorderSide(color: Color(0xFFDBEAFE)),
+        side: BorderSide(color: borderColor),
       ),
       child: Padding(
         padding: const EdgeInsets.all(20.0),
@@ -79,14 +95,14 @@ class _RotatingInfoCardState extends State<RotatingInfoCard>
           children: [
             Row(
               children: [
-                const Icon(LucideIcons.info, color: Color(0xFF3B82F6)),
+                Icon(LucideIcons.info, color: primaryColor),
                 const SizedBox(width: 8),
                 Text(
                   AppLocalizations.of(context)!.stay_informed,
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 18,
                     fontWeight: FontWeight.w600,
-                    color: Color(0xFF1E40AF),
+                    color: headlineColor,
                   ),
                 ),
               ],
@@ -99,9 +115,9 @@ class _RotatingInfoCardState extends State<RotatingInfoCard>
                 child: Text(
                   _infoItems[_currentIndex],
                   textAlign: TextAlign.center,
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 16,
-                    color: Color(0xFF1D4ED8),
+                    color: bodyColor,
                     height: 1.5,
                   ),
                 ),

--- a/lib/features/home/presentation/view/widgets/signal_strength_text.dart
+++ b/lib/features/home/presentation/view/widgets/signal_strength_text.dart
@@ -1,50 +1,38 @@
 import 'package:flutter/material.dart';
-
-enum SignalQuality { poor, normal, excellent }
+import 'package:maxt_diagnostic/core/config/app_config.dart';
+import 'package:maxt_diagnostic/core/di/injection_container.dart' as di;
+import 'package:maxt_diagnostic/core/theme/brand_theme_colors.dart';
 
 class SignalStrengthText extends StatelessWidget {
-  final int strengthInDbm;
+  final SignalQuality quality;
 
-  const SignalStrengthText({super.key, required this.strengthInDbm});
+  const SignalStrengthText({super.key, required this.quality});
 
-  SignalQuality _getSignalQuality(int dBm) {
-    final absStrength = dBm.abs();
-    if (absStrength <= 55) return SignalQuality.excellent;
-    if (absStrength <= 70) return SignalQuality.normal;
-    return SignalQuality.poor;
-  }
-
-  Color _getQualityColor(SignalQuality quality) {
+  Color _getQualityColor(BuildContext context) {
+    final brandColors =
+        Theme.of(context).extension<BrandThemeColors>()!;
     switch (quality) {
       case SignalQuality.excellent:
-        return const Color(0xFF16A34A); // Green
+        return brandColors.signalExcellent;
       case SignalQuality.normal:
-        return const Color(0xFFD97706); // Amber
+        return brandColors.signalNormal;
       case SignalQuality.poor:
-        return const Color(0xFFDC2626); // Red
+        return brandColors.signalPoor;
     }
   }
 
-  String _getQualityLabel(SignalQuality quality) {
-    switch (quality) {
-      case SignalQuality.excellent:
-        return 'Excelente';
-      case SignalQuality.normal:
-        return 'Normal';
-      case SignalQuality.poor:
-        return 'Ruim';
-    }
+  String _getQualityLabel() {
+    return di.sl<AppConfig>().qualityLabel(quality);
   }
 
   @override
   Widget build(BuildContext context) {
-    final quality = _getSignalQuality(strengthInDbm);
     return Text(
-      _getQualityLabel(quality),
+      _getQualityLabel(),
       style: TextStyle(
         fontSize: 18,
         fontWeight: FontWeight.w600,
-        color: _getQualityColor(quality),
+        color: _getQualityColor(context),
       ),
     );
   }

--- a/lib/features/results/presentation/results_screen.dart
+++ b/lib/features/results/presentation/results_screen.dart
@@ -27,8 +27,7 @@ class ResultsScreen extends StatelessWidget {
           icon: const Icon(LucideIcons.arrowLeft),
           onPressed: () => context.go('/'),
         ),
-        title: const Text('MAX INTERNET',
-            style: TextStyle(fontWeight: FontWeight.bold)),
+        title: const Text('MAX DIAGNÓSTICO'),
         centerTitle: true,
       ),
       body: Column(

--- a/lib/features/results/presentation/results_screen.dart
+++ b/lib/features/results/presentation/results_screen.dart
@@ -241,11 +241,19 @@ class _FooterActions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
     return Container(
       padding: const EdgeInsets.all(16.0),
       decoration: BoxDecoration(
-          color: Colors.white,
-          border: Border(top: BorderSide(color: Colors.grey.shade200))),
+        color: theme.cardColor,
+        border: Border(
+          top: BorderSide(
+            color: theme.dividerTheme.color ?? Colors.grey.shade200,
+          ),
+        ),
+      ),
       child: Row(
         children: [
           Expanded(
@@ -254,8 +262,8 @@ class _FooterActions extends StatelessWidget {
               label: const Text('Exportar Relatório'),
               onPressed: () => _onShare(context),
               style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFF4F46E5),
-                foregroundColor: Colors.white,
+                backgroundColor: colorScheme.primary,
+                foregroundColor: colorScheme.onPrimary,
                 padding: const EdgeInsets.symmetric(vertical: 14),
                 shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12)),
@@ -269,8 +277,8 @@ class _FooterActions extends StatelessWidget {
               label: const Text('Novo Teste'),
               onPressed: () => context.go('/diagnostic'),
               style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFFE0E7FF),
-                foregroundColor: const Color(0xFF4338CA),
+                backgroundColor: colorScheme.secondary,
+                foregroundColor: colorScheme.onSecondary,
                 padding: const EdgeInsets.symmetric(vertical: 14),
                 shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12)),

--- a/lib/features/results/presentation/results_screen.dart
+++ b/lib/features/results/presentation/results_screen.dart
@@ -108,9 +108,6 @@ class _ResultSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-      elevation: 2,
-      shadowColor: Colors.black.withAlpha(13),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       child: Padding(
         padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
         child: Column(

--- a/lib/features/results/presentation/view/widgets/advice_card.dart
+++ b/lib/features/results/presentation/view/widgets/advice_card.dart
@@ -1,24 +1,33 @@
 import 'package:flutter/material.dart';
 import 'package:lucide_icons/lucide_icons.dart';
+import 'package:maxt_diagnostic/core/theme/brand_theme_colors.dart';
 import 'package:maxt_diagnostic/domain/entities/advice_entity.dart';
 
 class AdviceCard extends StatelessWidget {
   final AdviceEntity advice;
+
   const AdviceCard({super.key, required this.advice});
 
   @override
   Widget build(BuildContext context) {
-    final theme = _getTheme(advice.severity);
+    final brandColors =
+        Theme.of(context).extension<BrandThemeColors>()!;
+    final severityColors = _colorsForSeverity(brandColors, advice.severity);
+
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: theme.backgroundColor,
+        color: severityColors.background,
         borderRadius: BorderRadius.circular(16),
       ),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Icon(theme.iconData, color: theme.iconColor, size: 24),
+          Icon(
+            _iconForSeverity(advice.severity),
+            color: severityColors.icon,
+            size: 24,
+          ),
           const SizedBox(width: 16),
           Expanded(
             child: Column(
@@ -27,15 +36,19 @@ class AdviceCard extends StatelessWidget {
                 Text(
                   advice.title,
                   style: TextStyle(
-                      fontSize: 17,
-                      fontWeight: FontWeight.bold,
-                      color: theme.titleColor),
+                    fontSize: 17,
+                    fontWeight: FontWeight.bold,
+                    color: severityColors.title,
+                  ),
                 ),
                 const SizedBox(height: 4),
                 Text(
                   advice.description,
                   style: TextStyle(
-                      fontSize: 15, color: theme.textColor, height: 1.4),
+                    fontSize: 15,
+                    color: severityColors.text,
+                    height: 1.4,
+                  ),
                 ),
               ],
             ),
@@ -45,52 +58,31 @@ class AdviceCard extends StatelessWidget {
     );
   }
 
-  _AdviceTheme _getTheme(AdviceSeverity severity) {
+  AdviceColors _colorsForSeverity(
+    BrandThemeColors colors,
+    AdviceSeverity severity,
+  ) {
     switch (severity) {
       case AdviceSeverity.critical:
-        return _AdviceTheme(
-            backgroundColor: const Color(0xFFFEF2F2),
-            iconColor: const Color(0xFFEF4444),
-            titleColor: const Color(0xFFB91C1C),
-            textColor: const Color(0xFF991B1B),
-            iconData: LucideIcons.alertTriangle);
+        return colors.adviceCritical;
       case AdviceSeverity.warning:
-        return _AdviceTheme(
-            backgroundColor: const Color(0xFFFFFBEB),
-            iconColor: const Color(0xFFF59E0B),
-            titleColor: const Color(0xFFB45309),
-            textColor: const Color(0xFF92400E),
-            iconData: LucideIcons.alertTriangle);
+        return colors.adviceWarning;
       case AdviceSeverity.good:
-        return _AdviceTheme(
-            backgroundColor: const Color(0xFFF0FDF4),
-            iconColor: const Color(0xFF22C55E),
-            titleColor: const Color(0xFF15803D),
-            textColor: const Color(0xFF166534),
-            iconData: LucideIcons.checkCircle2);
+        return colors.adviceGood;
       case AdviceSeverity.info:
-        return _AdviceTheme(
-            backgroundColor: const Color(0xFFEFF6FF),
-            iconColor: const Color(0xFF3B82F6),
-            titleColor: const Color(0xFF1E40AF),
-            textColor: const Color(0xFF1D4ED8),
-            iconData: LucideIcons.info);
+        return colors.adviceInfo;
     }
   }
-}
 
-class _AdviceTheme {
-  final Color backgroundColor;
-  final Color iconColor;
-  final Color titleColor;
-  final Color textColor;
-  final IconData iconData;
-
-  _AdviceTheme({
-    required this.backgroundColor,
-    required this.iconColor,
-    required this.titleColor,
-    required this.textColor,
-    required this.iconData,
-  });
+  IconData _iconForSeverity(AdviceSeverity severity) {
+    switch (severity) {
+      case AdviceSeverity.critical:
+      case AdviceSeverity.warning:
+        return LucideIcons.alertTriangle;
+      case AdviceSeverity.good:
+        return LucideIcons.checkCircle2;
+      case AdviceSeverity.info:
+        return LucideIcons.info;
+    }
+  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -397,6 +397,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.8.1"
+  google_fonts:
+    dependency: "direct main"
+    description:
+      name: google_fonts
+      sha256: "517b20870220c48752eafa0ba1a797a092fb22df0d89535fd9991e86ee2cdd9c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
   http:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   lucide_icons: ^0.257.0
   flutter_html_to_pdf: ^0.7.0
   path_provider: ^2.1.5
+  google_fonts: ^6.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 📋 Description

This PR is a comprehensive visual and user-experience overhaul of the entire application. It addresses core issues of visual inconsistency, "jank" (lag) during navigation, and confusing user feedback during the diagnostic test.

The goal was to align the app with a more professional, minimal, and consistent design language (inspired by the "mk agents" examples), fix performance bottlenecks, and improve the user's "story" during the testing phase.

## 🔗 Related Issue

Fixes #(issue)

## 🧪 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup
- [x] ♻️ Refactoring (A major refactor of the entire UI/UX layer)

## 📝 How Has This Been Tested?

- [ ] Unit tests pass
- [x] Manual testing completed (Iterative testing of each visual/performance change)
- [ ] CI/CD pipeline passes

## 📷 Screenshots (if applicable)

*(N/A - Changes are architectural and UX-based)*

## ✅ Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## 🔄 Dependencies

- Added `google_fonts` package.

## 📚 Additional Notes

This PR can be broken down into three main categories of improvement:

### 1. Visual Identity & Hierarchy (Theme)
- **Background/Card Contrast**: Implemented the core "mk agents" design principle. The global `scaffoldBackgroundColor` is now `F1F5F9` (Slate 100), and the global `CardTheme` uses `elevation` and soft shadows. This provides depth and clear hierarchy.
- **Card Cleanup**: Removed all local `elevation`, `shadowColor`, and `shape` overrides from all cards (`NetworkInfoCard`, `QuickTipsCard`, `_ResultSection`, etc.) to enforce the single global `CardTheme`.
- **Branding Unification**: Replaced all instances of "MAX INTERNET" and "MaxT Diagnostic" with "MAX DIAGNÓSTICO".
- **Structural Consistency**:
    - Fixed the "floating" title on the `DiagnosticLoadingScreen` by adding a proper `AppBar`.
    - Fixed the duplicate title on the `HomeScreen` by removing the body text, centering the `AppBar` title, and styling "Status da Rede" as a centered header.
- **Font**: Added `google_fonts` and set "Inter" as the default `textTheme` in `AppTheme`.

### 2. Semantic Color Palette (ThemeExtension)
- **Centralized Colors**: Created `BrandThemeColors` (`ThemeExtension`) to act as a single source of truth for all non-theme colors.
- **Refactored Widgets**: All widgets that previously used hardcoded colors for states (e.g., `AdviceCard`, `TestItemCard`, `SignalStrengthText`) were refactored to be "dumb" presenters that pull their colors directly from the `BrandThemeColors` extension.

### 3. Diagnostic Screen UX & Performance (The "Jank" Fix)
This screen received a complete architectural overhaul to fix all perceived "lags" and "raw" UI states.
- **Fixes Navigation Jank (Lag)**:
    1.  Introduced an `_isUiReady` state. The screen now loads a lightweight `CircularProgressIndicator` for 300ms.
    2.  This allows the navigation animation to complete smoothly.
    3.  Only *after* 300ms does the heavy UI (`PulsingWifiIcon`, etc.) fade in via an `AnimatedSwitcher`.
- **Fixes Test Start Lag & Bugs**:
    1.  The actual `startTest()` call is now deferred and only triggered by the *first* tick of the `Timer` (after 3.5 seconds).
    2.  This gives the UI 3.5s to be completely stable, fixing *all* remaining jank and resolving a race condition where the progress bar would jump.
- **Fixes "Raw" Pre-Test State**:
    - While the state is `pending` (during the first 3.5s), the UI now shows an **indeterminate** `LinearProgressIndicator` (shimmer) instead of a "broken" empty bar.
- **Fixes "Raw" Post-Test State**:
    - When `complete`, the `_buildProgressBar` now shows a full 100% bar (`value: 1.0`).
    - The "Não feche" alert remains visible (via `AnimatedOpacity`).
    - This makes the screen feel "finished" during the 1.5s delay before navigating, not "broken".
- **Fixes Status Text Pacing**:
    - Replaced all technical/fast-changing status text (`state.currentStage.displayName`).
    - Implemented a `StatefulWidget` with a `Timer` to cycle through a list of "natural" status messages at a calm 3.5-second interval. This provides a smooth, rhythmic, and professional user experience.

